### PR TITLE
Remove SHA sums from image names to avoid Origin 1.5.1 issue

### DIFF
--- a/znc-template-basic.yaml
+++ b/znc-template-basic.yaml
@@ -56,7 +56,7 @@ objects:
           deploymentconfig: znc-cluster-app
       spec:
         containers:
-        - image: nhripps/znc-cluster-app@sha256:cf496fa3969f044a3cbc1d43042adacb4f6653500922f65b8dd06178a9523acd
+        - image: nhripps/znc-cluster-app
           imagePullPolicy: Always
           name: znc-cluster-app
           ports:

--- a/znc-template-complete.yaml
+++ b/znc-template-complete.yaml
@@ -52,7 +52,7 @@ objects:
             value: "${ZNC_PASS}"
           - name: ZNC_NAME
             value: "${ZNC_NAME}"
-          image: nhripps/znc-cluster-app@sha256:cf496fa3969f044a3cbc1d43042adacb4f6653500922f65b8dd06178a9523acd
+          image: nhripps/znc-cluster-app
           imagePullPolicy: Always
           name: znc-cluster-app
           ports:

--- a/znc-template-with-params.yaml
+++ b/znc-template-with-params.yaml
@@ -58,7 +58,7 @@ objects:
             value: "${ZNC_PASS}"
           - name: ZNC_NAME
             value: "${ZNC_NAME}"
-          image: nhripps/znc-cluster-app@sha256:cf496fa3969f044a3cbc1d43042adacb4f6653500922f65b8dd06178a9523acd
+          image: nhripps/znc-cluster-app
           imagePullPolicy: Always
           name: znc-cluster-app
           ports:

--- a/znc-template-with-pvc.yaml
+++ b/znc-template-with-pvc.yaml
@@ -58,7 +58,7 @@ objects:
             value: "${ZNC_PASS}"
           - name: ZNC_NAME
             value: "${ZNC_NAME}"
-          image: nhripps/znc-cluster-app@sha256:cf496fa3969f044a3cbc1d43042adacb4f6653500922f65b8dd06178a9523acd
+          image: nhripps/znc-cluster-app
           imagePullPolicy: Always
           name: znc-cluster-app
           ports:


### PR DESCRIPTION
This is to address https://github.com/openshift/origin/issues/15136